### PR TITLE
[Fix]. 草稿文章时间戳为负

### DIFF
--- a/WordpressToTypecho/Action.php
+++ b/WordpressToTypecho/Action.php
@@ -176,7 +176,7 @@ class WordpressToTypecho_Action extends Typecho_Widget implements Widget_Interfa
                     'cid'           =>  $row['ID'],
                     'title'         =>  $row['post_title'],
                     'slug'          =>  Typecho_Common::slugName(urldecode($row['post_name']), $row['ID'], 128),
-                    'created'       =>  strtotime($row['post_date_gmt']) + $gmtOffset,
+                    'created'       =>  strtotime($row['post_date_gmt']) + $gmtOffset > 0 ? strtotime($row['post_date_gmt']) + $gmtOffset : 0,
                     'modified'      =>  strtotime($row['post_modified_gmt']) + $gmtOffset,
                     'text'          =>  $row['post_content'],
                     'order'         =>  $row['menu_order'],


### PR DESCRIPTION
WordPress 草稿文章 GMT 时间为 “0000-00-00 00:00:00”  strtotime 转化后为负数。文章插入报错。